### PR TITLE
use sin in Tensor.randn

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -201,7 +201,7 @@ class Tensor:
   def randn(*shape, dtype:Optional[DType]=None, **kwargs) -> Tensor:
     # https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform
     src = Tensor.rand(2, *shape, **kwargs)
-    return src[0].mul(2*math.pi).cos().mul((1 - src[1]).log().mul(-2).sqrt()).cast(Tensor.default_type if dtype is None else dtype)
+    return src[0].mul(2*math.pi).sin().mul((1 - src[1]).log().mul(-2).sqrt()).cast(dtype or Tensor.default_type)
 
   @staticmethod
   def randint(*shape, low=0, high=10, **kwargs) -> Tensor: return Tensor.uniform(shape, low=low, high=high, dtype=dtypes.int32)


### PR DESCRIPTION
it's the same distribution, but sin is tiygrad primitive op so resulted in 10% less OPS