### PR TITLE
fix PADTO optimization

### DIFF
--- a/extra/autopad.py
+++ b/extra/autopad.py
@@ -15,13 +15,11 @@ lin = Linearizer(sched[0].ast)
 
 lin.apply_opt(Opt(op=OptOps.PADTO, axis=0, amt=32))
 lin.apply_opt(Opt(op=OptOps.PADTO, axis=1, amt=32))
-lin.apply_opt(Opt(op=OptOps.PADTO, axis=2, amt=32))
 lin.hand_coded_optimizations()
 lin.linearize()
 print(f"{lin.applied_opts=}")
 
 run_linearizer(lin)
-quit()
 
 ###
 
@@ -30,11 +28,9 @@ sched = [si for si in a.lazydata.schedule() if si.ast.op not in LoadOps]
 assert len(sched) == 1
 lin = Linearizer(sched[0].ast)
 
-# lin.apply_opt(Opt(op=OptOps.LOCAL, axis=0, amt=32))
-
 lin.apply_opt(Opt(op=OptOps.PADTO, axis=0, amt=32))
-lin.apply_opt(Opt(op=OptOps.PADTO, axis=1, amt=32))
 lin.hand_coded_optimizations()
 lin.linearize()
+print(f"{lin.applied_opts=}")
 
 run_linearizer(lin)

--- a/extra/optimization/test_beam_search.py
+++ b/extra/optimization/test_beam_search.py
@@ -17,11 +17,25 @@ class TestBeamSearch(unittest.TestCase):
     a = Tensor.rand(3, 3).reshape((Variable("a", 1, 10).bind(3), 3))
     a = (a+1).realize()
 
-  def test_big_prime_number(self):
+  def test_big_prime_number_matmul(self):
     a = Tensor.rand(367, 367)
     b = Tensor.rand(367, 367)
     c = (a@b).realize()
     np.testing.assert_allclose(c.numpy(), a.numpy() @ b.numpy(), atol=1e-4, rtol=1e-4)
+
+  def test_big_prime_number_max(self):
+    a = -Tensor.rand(367, 367)
+    b = Tensor.rand(367, 367)
+    # if incorrectly padded 0, the max would be 0 instead of a negative number
+    c = (a*b).max(1)
+    np.testing.assert_allclose(c.numpy(), (a.numpy() * b.numpy()).max(1), atol=1e-4, rtol=1e-4)
+
+  def test_big_prime_number_sum(self):
+    a = Tensor.rand(367, 367)
+    b = Tensor.rand(367, 367)
+    # if incorrectly padded 0, the sum would be inf
+    c = (a/b).sum(1).realize()
+    np.testing.assert_allclose(c.numpy(), (a.numpy() / b.numpy()).sum(1), atol=1e-4, rtol=1e-4)
 
   def test_variable_big_prime_number(self):
     v = Variable("v", 1, 400).bind(367)

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -452,7 +452,7 @@ class Kernel:
       self.dont_use_locals = True
     elif opt.op == OptOps.PADTO:
       assert not vars_from_ast(self.ast), "does not work with symbolic shape"
-      assert all(op.op is not ReduceOps.MAX for op in self.ast.lazyops), "cannot pad with MAX"
+      assert axis < self.first_reduce, "cannot pad a reduce axis"
       padded = False
       for i,st in enumerate(self.sts):
         if self.sts[i].shape[axis] != 1:

--- a/tinygrad/features/search.py
+++ b/tinygrad/features/search.py
@@ -13,8 +13,7 @@ actions = flatten([[Opt(op=OptOps.UPCAST, axis=axis, amt=amt) for amt in [0,2,3,
 actions += flatten([[Opt(op=OptOps.UNROLL, axis=axis, amt=amt) for amt in [0,4]] for axis in range(4)])
 actions += flatten([[Opt(op=OptOps.LOCAL, axis=axis, amt=amt) for amt in [2,3,4,8,13,16,29]] for axis in range(5)])
 actions += flatten([[Opt(op=OptOps.GROUPTOP, axis=axis, amt=amt) for amt in [13,16,29,32,256]] for axis in range(3)])
-# TODO: fix PADTO. in addition to STORE, it also needs to gate acc update
-# actions += flatten([[Opt(op=OptOps.PADTO, axis=axis, amt=amt) for amt in [32]] for axis in range(7)])
+actions += flatten([[Opt(op=OptOps.PADTO, axis=axis, amt=amt) for amt in [32]] for axis in range(7)])
 actions += [
   Opt(op=OptOps.LOCAL, axis=0, amt=32),
   Opt(op=OptOps.GROUP, axis=0, amt=4), Opt(op=OptOps.GROUP, axis=0, amt=8), Opt(op=OptOps.GROUP, axis=1, amt=8),


### PR DESCRIPTION
the correct condition is that PADTO cannot be applied to reduce axis, not Reduce.MAX in ops. even for Reduce.SUM it's possible that the reduce axis had a div before, and the padded 0 became inf then sum over it is incorrect.