### PR TITLE
remove AndNode.__floordiv__

### DIFF
--- a/test/unit/test_symbolic.py
+++ b/test/unit/test_symbolic.py
@@ -42,6 +42,9 @@ class TestSymbolic(unittest.TestCase):
     expr = Node.ands([(Variable("idx1", 0, 511)*4 + Variable("FLOAT4_INDEX", 0, 3)) < 512,
                       (Variable("idx2", 0, 511)*4 + Variable("FLOAT4_INDEX", 0, 3)) < 512])
     self.helper_test_variable(expr, 0, 1, "((idx1<128) and (idx2<128))")
+    expr = Node.ands([(Variable("idx1", 0, 511)*4 + Variable("FLOAT4_INDEX", 0, 3)) < 512,
+                      (Variable("idx2", 0, 511)*4 + Variable("FLOAT8_INDEX", 0, 7)) < 512])
+    self.helper_test_variable(expr//4, 0, 0, "0")
 
   def test_lt_factors(self):
     expr = Node.ands([(Variable("idx1", 0, 511)*4 + Variable("FLOAT4_INDEX", 0, 256)) < 512])

--- a/test/unit/test_symbolic.py
+++ b/test/unit/test_symbolic.py
@@ -42,9 +42,6 @@ class TestSymbolic(unittest.TestCase):
     expr = Node.ands([(Variable("idx1", 0, 511)*4 + Variable("FLOAT4_INDEX", 0, 3)) < 512,
                       (Variable("idx2", 0, 511)*4 + Variable("FLOAT4_INDEX", 0, 3)) < 512])
     self.helper_test_variable(expr, 0, 1, "((idx1<128) and (idx2<128))")
-    expr = Node.ands([(Variable("idx1", 0, 511)*4 + Variable("FLOAT4_INDEX", 0, 3)) < 512,
-                      (Variable("idx2", 0, 511)*4 + Variable("FLOAT8_INDEX", 0, 7)) < 512])
-    self.helper_test_variable(expr//4, 0, 1, "((((FLOAT8_INDEX//4)+idx2)<128) and ((idx1//4)<32))")
 
   def test_lt_factors(self):
     expr = Node.ands([(Variable("idx1", 0, 511)*4 + Variable("FLOAT4_INDEX", 0, 256)) < 512])

--- a/tinygrad/shape/symbolic.py
+++ b/tinygrad/shape/symbolic.py
@@ -291,7 +291,6 @@ class SumNode(RedNode):
   def flat_components(self): return [y for x in self.nodes for y in (x.flat_components if isinstance(x, SumNode) else [x])]
 
 class AndNode(RedNode):
-  def __floordiv__(self, b: Union[Node, int], _=True): return Node.ands([x//b for x in self.nodes])
   def substitute(self, var_vals: Dict[Variable, Node]) -> Node:
     subed = []
     for node in self.nodes:


### PR DESCRIPTION
AndNode produces a Node that min/max is bounded by [0, 1] so `//` on top of that is almost always 0. we don't really use that too