### PR TITLE
properly exclude PYTHON backend and support of half

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -1,12 +1,10 @@
-import unittest
+import unittest, operator, sys
 import numpy as np
 import torch
-import operator
+from typing import Any, List
 from tinygrad.helpers import CI, getenv, DEBUG, OSX, temp
 from tinygrad.dtype import DType, DTYPES_DICT, ImageDType, PtrDType, least_upper_float, least_upper_dtype
-from tinygrad import Device
-from tinygrad.tensor import Tensor, dtypes
-from typing import Any, List
+from tinygrad import Device, Tensor, dtypes
 from hypothesis import given, settings, strategies as strat
 
 settings.register_profile("my_profile", max_examples=200, deadline=None)
@@ -21,7 +19,9 @@ def is_dtype_supported(dtype: DType, device: str = Device.DEFAULT):
   # for CI LLVM, it segfaults because it can't link to the casting function
   # CUDA in CI uses CUDACPU that does not support half
   # PYTHON supports half memoryview in 3.12+ https://github.com/python/cpython/issues/90751
-  if dtype == dtypes.half: return not (CI and device in ["GPU", "LLVM", "CUDA"]) and device != "PYTHON"
+  if dtype == dtypes.half:
+    if device in ["GPU", "LLVM", "CUDA"]: return not CI
+    if device == "PYTHON": return sys.version_info >= (3, 12)
   if dtype == dtypes.float64: return device != "METAL" and not (OSX and device == "GPU")
   return True
 


### PR DESCRIPTION
should be able to run in CI with python 3.12