### PR TITLE
clean up clang src header

### DIFF
--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -4,7 +4,7 @@ from tinygrad.helpers import cpu_time_execution
 from tinygrad.codegen.kernel import LinearizerOptions
 from tinygrad.renderer.cstyle import uops_to_cstyle, CStyleLanguage
 
-CLANG_PROGRAM_HEADER = '#include <math.h>\n#define max(x,y) ((x>y)?x:y)\n#define int64 long\n#define half __fp16\n#define uchar unsigned char\n#include <stdbool.h>\n'  # noqa: E501
+CLANG_PROGRAM_HEADER = '#include <stdbool.h>\n#include <math.h>\n#define max(x,y) ((x>y)?x:y)\n#define half __fp16\n'
 
 class ClangCompiler(Compiler):
   linearizer_opts = LinearizerOptions("CLANG", supports_float4=False, has_local=False)


### PR DESCRIPTION
don't need to define int64 and uchar