### PR TITLE
always use f32 for source of randn

### DIFF
--- a/test/test_randomness.py
+++ b/test/test_randomness.py
@@ -103,7 +103,7 @@ class TestRandomness(unittest.TestCase):
     self.assertTrue(normal_test(Tensor.randn))
     self.assertTrue(equal_distribution(Tensor.randn, torch.randn, lambda x: np.random.randn(*x)))
 
-  @given(strat.sampled_from([dtypes.float, dtypes.float16]))#, dtypes.bfloat16]))  # TODO: add bfloat16
+  @given(strat.sampled_from([dtypes.float, dtypes.float16, dtypes.bfloat16]))
   @unittest.skipIf(Device.DEFAULT=="RHIP", "broken in HIP CI")
   def test_randn_finite(self, default_float):
     if not is_dtype_supported(default_float): return
@@ -113,10 +113,9 @@ class TestRandomness(unittest.TestCase):
     t = Tensor.randn(1024, 1024)
     mx = t.max().numpy().item()
     mn = t.min().numpy().item()
-    if default_float == dtypes.float or (default_float == dtypes.float16 and not THREEFRY.value):
-      print(f"testing with {default_float=}")
-      assert math.isfinite(mx), mx
-      assert math.isfinite(mn), mn
+    print(f"testing with {default_float=}")
+    assert math.isfinite(mx), mx
+    assert math.isfinite(mn), mn
     dtypes.default_float = old_default_float
 
   def test_randint(self):

--- a/test/test_randomness.py
+++ b/test/test_randomness.py
@@ -104,7 +104,8 @@ class TestRandomness(unittest.TestCase):
     self.assertTrue(equal_distribution(Tensor.randn, torch.randn, lambda x: np.random.randn(*x)))
 
   @given(strat.sampled_from([dtypes.float, dtypes.float16, dtypes.bfloat16]))
-  @unittest.skipIf(Device.DEFAULT=="RHIP", "broken in HIP CI")
+  @unittest.skipIf(Device.DEFAULT=="RHIP", "float16 broken in HIP CI")
+  @unittest.skipIf(Device.DEFAULT=="HSA", "bfloat16 local buffer broken in HSA")
   def test_randn_finite(self, default_float):
     if not is_dtype_supported(default_float): return
     old_default_float = dtypes.default_float

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -292,7 +292,7 @@ class Tensor:
   @staticmethod
   def randn(*shape, dtype:Optional[DType]=None, **kwargs) -> Tensor:
     # https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform
-    src = Tensor.rand((2, *argfix(*shape)), **kwargs)
+    src = Tensor.rand((2, *argfix(*shape)), **{**kwargs, "dtype": dtypes.float32})
     return src[0].mul(2*math.pi).cos().mul((1 - src[1]).log().mul(-2).sqrt()).cast(dtype or dtypes.default_float)
 
   @staticmethod


### PR DESCRIPTION
fixed bfloat16 randn to not have inf.
don't really care about float64. threefry is float32 based too