### PR TITLE
clean up Device methods [pr]

### DIFF
--- a/test/unit/test_device.py
+++ b/test/unit/test_device.py
@@ -18,6 +18,11 @@ class TestDevice(unittest.TestCase):
     assert Device.canonicalize("gpu:1") == "GPU:1"
     assert Device.canonicalize("GPU:2") == "GPU:2"
     assert Device.canonicalize("disk:/dev/shm/test") == "DISK:/dev/shm/test"
+    assert Device.canonicalize("disk:000.txt") == "DISK:000.txt"
+
+  def test_getitem_not_exist(self):
+    with self.assertRaises(ModuleNotFoundError):
+      Device["TYPO"]
 
 class MockCompiler(Compiler):
   def __init__(self, key): super().__init__(key)


### PR DESCRIPTION
- fixed `_canonicalize` if it's `"DISK:000.txt"`.
- moved _devices to `DEFAULT`, `__get_canonicalized_item` does not need it because it would hit ModuleNotFoundError.
- removed # noqa: E501