### PR TITLE
update SimpleMathTrait.ufix

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -42,7 +42,7 @@ class SimpleMathTrait:
   def const_like(self:T, b:ConstType|Variable|Tuple[ConstType]) -> T: raise NotImplementedError
 
   # great functions you get!
-  def ufix(self, x): return self.const_like(x) if not isinstance(x, MathTrait) else x
+  def ufix(self, x): return self.const_like(x) if not isinstance(x, type(self)) else x
   def _binop(self, op, x, reverse): return self.ufix(x).alu(op, self) if reverse else self.alu(op, self.ufix(x))
   def logical_not(self): return self.ne(True)
   def neg(self):


### PR DESCRIPTION
use `isinstance(x, type(self))` instead of `isinstance(x, MathTrait)`. the former can guarantee the returned type is the same as self, which the latter would give `type(self) | MathTrait`