### PR TITLE
hotfix remove float16 bitcast in frexp

### DIFF
--- a/tinygrad/codegen/transcendental.py
+++ b/tinygrad/codegen/transcendental.py
@@ -71,7 +71,6 @@ def frexp(v:UOp) -> Tuple[UOp, UOp]:
   # special case of 0  # TODO: can we remove this case?
   mantissa = exponent.ne(0).where(mantissa, v)
   exp = exponent.ne(0).where(exp, exp.const_like(0))
-  if v.dtype == dtypes.float16: exp = exp.bitcast(dtypes.int16)
   return mantissa, exp
 
 def polyN(s:UOp, coeffs:List[float]) -> UOp: return functools.reduce(lambda u,c: u*s+c, coeffs, s.const_like(0))


### PR DESCRIPTION
it does not matter because the only usage takes the final 5 bits immediately after. so good to remove dtype specific logic