### PR TITLE
remove reassoc from LLVM flags

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -42,7 +42,8 @@ def is_dtype_supported(dtype: DType, device: str = Device.DEFAULT):
   # PYTHON supports half memoryview in 3.12+ https://github.com/python/cpython/issues/90751
   if dtype == dtypes.half:
     if device == "GPU": return not CI and not OSX
-    if device in ["LLVM", "CUDA", "NV"]: return not CI
+    if device in ["CUDA", "NV"]: return not CI
+    if device == "LLVM": return OSX
     if device == "PYTHON": return sys.version_info >= (3, 12)
   if dtype == dtypes.float64: return device != "METAL" and not (OSX and device == "GPU")
   return True

--- a/test/test_transcendental.py
+++ b/test/test_transcendental.py
@@ -40,7 +40,6 @@ class TestTranscendentalMath(unittest.TestCase):
                                  op[1](np.array([x], dtype=_to_np_dtype(dtypes.float16))),
                                  atol=1e-2, rtol=5e-3)  # exp can have bigger rtol
 
-  @unittest.skipIf(Device.DEFAULT=="LLVM", "FIXME: LLVM might change compute")
   @given(strat.sampled_from([(dtypes.float64, 709.5), (dtypes.float32, 88.7), (dtypes.float16, 11)]))
   def test_exp_near_inf(self, dtype_x):
     # reordering compute might return inf

--- a/tinygrad/renderer/llvmir.py
+++ b/tinygrad/renderer/llvmir.py
@@ -4,7 +4,7 @@ from tinygrad.dtype import DType, PtrDType, dtypes
 from tinygrad.ops import Op, UnaryOps, BinaryOps, TernaryOps, Ops, UOp
 from tinygrad.renderer import Renderer
 
-MFLAGS = ('nsz', 'arcp', 'contract', 'afn', 'reassoc') # All from fast math, but nnan and ninf
+MFLAGS = ('nsz', 'arcp', 'contract', 'afn') # All from fast math, but nnan and ninf and reassoc
 
 def is_bool_or_unsigned(dtype: DType): return dtype == dtypes.bool or dtypes.is_unsigned(dtype)
 


### PR DESCRIPTION
reassoc reorders compute and breaks transcendental