### PR TITLE
remove `from __future__ import annotations`

### DIFF
--- a/examples/so_vits_svc.py
+++ b/examples/so_vits_svc.py
@@ -1,5 +1,4 @@
 # original implementation: https://github.com/svc-develop-team/so-vits-svc
-from __future__ import annotations
 import sys, logging, time, io, math, argparse, operator, numpy as np
 from functools import partial, reduce
 from pathlib import Path

--- a/extra/backends/ops_dsp.py
+++ b/extra/backends/ops_dsp.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import Tuple, Any, List
 import ctypes, os, mmap, tempfile, pathlib, array, functools, threading, contextlib, sys
 assert sys.platform != 'win32'

--- a/extra/backends/ops_hsa.py
+++ b/extra/backends/ops_hsa.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import ctypes, functools, subprocess, io, atexit, collections, json
 from typing import Tuple, TypeVar, List, Dict, Any
 import tinygrad.runtime.autogen.hsa as hsa

--- a/extra/mcts_search.py
+++ b/extra/mcts_search.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import List, Optional, Dict, cast
 import numpy as np
 np.set_printoptions(suppress=True)

--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import List, Dict, Union
 import importlib
 from functools import lru_cache

--- a/test/test_fuzz_shape_ops.py
+++ b/test/test_fuzz_shape_ops.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import unittest
 from math import prod
 

--- a/test/unit/test_verify_ast.py
+++ b/test/unit/test_verify_ast.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import unittest
 
 from tinygrad import Tensor

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import itertools, functools
 from dataclasses import dataclass
 from collections import defaultdict

--- a/tinygrad/codegen/lowerer.py
+++ b/tinygrad/codegen/lowerer.py
@@ -1,5 +1,4 @@
 # the job of the lowerer is to do indexing
-from __future__ import annotations
 import functools, itertools, operator
 from dataclasses import dataclass
 from typing import List, Tuple, cast, Optional

--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import Optional, Tuple, Dict, List, TYPE_CHECKING, Any, DefaultDict, Callable, Set
 import functools, itertools, operator
 from collections import defaultdict

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from dataclasses import dataclass, replace
 from collections import defaultdict
 from typing import Optional, Dict, Tuple, Any, Iterator

--- a/tinygrad/dtype.py
+++ b/tinygrad/dtype.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import Final, Optional, ClassVar, Set, Tuple, Dict, Union, Callable, Literal
 import math, struct, ctypes, functools
 from dataclasses import dataclass, fields

--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import TypeVar, Generic, Callable, List, Tuple, Union, Dict, cast, Optional, Any
 import functools, collections
 from tinygrad.tensor import Tensor

--- a/tinygrad/engine/lazy.py
+++ b/tinygrad/engine/lazy.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import Optional, Any, Tuple, List, get_args
 from tinygrad.dtype import dtypes, DType, ConstType, to_dtype, ImageDType
 from tinygrad.helpers import prod, getenv, all_int, all_same, DEBUG, _METADATA, Metadata, SPLIT_REDUCEOP, LAZYCACHE

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import os, functools, platform, time, re, contextlib, operator, hashlib, pickle, sqlite3, tempfile, pathlib, string, ctypes, sys, gzip
 import urllib.request, subprocess, shutil, math, contextvars, types, copyreg, inspect, importlib
 from dataclasses import dataclass

--- a/tinygrad/multi.py
+++ b/tinygrad/multi.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import Optional, Tuple, List, Dict
 import functools, itertools, operator
 from tinygrad.helpers import all_same, all_int, dedup, prod, DEBUG, RING, getenv

--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import math
 from typing import Optional, Union, Tuple, List
 from tinygrad.tensor import Tensor, dtypes

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import Any, List, Optional, Set, Union, Tuple, Dict, Callable, cast, TYPE_CHECKING, Type, DefaultDict
 import sys, time, functools, itertools, math, operator, hashlib, os, types, pickle, pathlib, inspect
 from enum import auto, IntEnum, Enum

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import Dict, List, Optional, Tuple, Union, DefaultDict, Literal, Callable, cast
 import os, math
 from collections import defaultdict, Counter

--- a/tinygrad/runtime/ops_amd.py
+++ b/tinygrad/runtime/ops_amd.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import Tuple, List, Any, Optional
 import os, ctypes, ctypes.util, functools, pathlib, mmap, errno, array, contextlib, sys
 assert sys.platform != 'win32'

--- a/tinygrad/runtime/ops_cloud.py
+++ b/tinygrad/runtime/ops_cloud.py
@@ -4,7 +4,6 @@
 # this client and server can be on the same machine, same network, or just same internet
 # it should be a secure (example: no use of pickle) boundary. HTTP is used for RPC
 
-from __future__ import annotations
 from typing import Tuple, Optional, Dict, Any, DefaultDict, List
 from collections import defaultdict
 from dataclasses import dataclass, field

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import ctypes, ctypes.util, functools
 from typing import Tuple, Optional, List
 from tinygrad.helpers import DEBUG, getenv, from_mv, init_c_var, init_c_struct_t

--- a/tinygrad/runtime/ops_disk.py
+++ b/tinygrad/runtime/ops_disk.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import os, sys, mmap, io, ctypes, ctypes.util, contextlib
 from typing import Optional, Generator, Tuple, Callable, List
 from tinygrad.helpers import OSX, round_up

--- a/tinygrad/runtime/ops_gpu.py
+++ b/tinygrad/runtime/ops_gpu.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import Tuple, Optional, List, cast
 import ctypes, functools, hashlib
 from tinygrad.runtime.autogen import opencl as cl

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import ctypes, functools
 from typing import Tuple
 from tinygrad.helpers import init_c_var, from_mv, init_c_struct_t, getenv

--- a/tinygrad/runtime/ops_llvm.py
+++ b/tinygrad/runtime/ops_llvm.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import ctypes, functools
 from typing import Tuple
 from tinygrad.device import Compiled, Compiler, MallocAllocator

--- a/tinygrad/runtime/ops_metal.py
+++ b/tinygrad/runtime/ops_metal.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import os, subprocess, pathlib, ctypes, tempfile, functools
 from typing import List, Any, Tuple, Optional, cast
 from tinygrad.helpers import prod, getenv, T

--- a/tinygrad/runtime/ops_nv.py
+++ b/tinygrad/runtime/ops_nv.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import os, ctypes, contextlib, re, fcntl, functools, mmap, struct, array, sys
 assert sys.platform != 'win32'
 from typing import Tuple, List, Any, cast, Union, Dict, Type, Optional

--- a/tinygrad/runtime/ops_qcom.py
+++ b/tinygrad/runtime/ops_qcom.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import os, ctypes, functools, mmap, struct, array, math, sys
 assert sys.platform != 'win32'
 from types import SimpleNamespace

--- a/tinygrad/runtime/support/elf.py
+++ b/tinygrad/runtime/support/elf.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import Tuple, List, Any
 from dataclasses import dataclass
 import tinygrad.runtime.autogen.libc as libc

--- a/tinygrad/runtime/support/hcq.py
+++ b/tinygrad/runtime/support/hcq.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import List, Optional, Dict, Tuple, cast, Protocol, Type, Union, TypeVar, Generic, Any
 import contextlib, decimal, statistics, random, json, atexit, time, ctypes
 from tinygrad.helpers import PROFILEPATH, PROFILE, from_mv, getenv, to_mv

--- a/tinygrad/shape/shapetracker.py
+++ b/tinygrad/shape/shapetracker.py
@@ -1,5 +1,4 @@
 # ShapeTracker allows movement operations to a buffer that don't require a copy to be made.
-from __future__ import annotations
 from dataclasses import dataclass
 from typing import Tuple, List, Optional, Dict, Set
 from tinygrad.helpers import merge_dicts, getenv

--- a/tinygrad/shape/view.py
+++ b/tinygrad/shape/view.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import functools, operator, itertools, math
 from dataclasses import dataclass
 from typing import Tuple, List, Optional, Dict, Set, cast

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1,5 +1,4 @@
 # inspired by https://github.com/karpathy/micrograd/blob/master/micrograd/engine.py
-from __future__ import annotations
 import time, math, itertools, functools, struct, sys, inspect, pathlib, string, dataclasses, hashlib
 from contextlib import ContextDecorator
 from typing import List, Tuple, Callable, Optional, ClassVar, Type, Union, Sequence, Dict, cast, get_args, Literal, TYPE_CHECKING, SupportsIndex


### PR DESCRIPTION
it's default in python 3.10+