### PR TITLE
simpler qk matmul for scaled_dot_product_attention

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -596,7 +596,7 @@ class TestTypeSpec(unittest.TestCase):
     assert X_data.gather(1, indices).dtype == X_data.dtype
 
   @given(strat.sampled_from(dtype_floats), strat.sampled_from(dtype_floats))
-  def test_attention_returns_same_dtype(self, data_dtype, default_float):
+  def test_scaled_dot_product_attention_returns_same_dtype(self, data_dtype, default_float):
     dtypes.default_float = default_float
     query = Tensor.rand(32, 8, 128, 64, dtype=data_dtype)
     key = Tensor.rand(32, 8, 128, 64, dtype=data_dtype)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3779,7 +3779,7 @@ class Tensor(SimpleMathTrait):
     """
     # NOTE: it also works when `key` and `value` have symbolic shape.
     assert all_int(self.shape), f"does not support symbolic shape {self.shape}"
-    qk = self.matmul(key.transpose(-2,-1), dtype=least_upper_dtype(self.dtype, key.dtype, dtypes.float32)) / math.sqrt(self.shape[-1])
+    qk = (self @ key.transpose(-2, -1)) / math.sqrt(self.shape[-1])
     # handle attention mask
     if is_causal:
       if attn_mask is not None: raise RuntimeError("cannot set attn_mask when is_causal=True")


### PR DESCRIPTION
don't hardcode float32 for sum acc dtype