### PR TITLE
mypy check extra/onnx.py

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -335,6 +335,7 @@ jobs:
         python -m mypy --strict-equality --lineprecision-report .
         cat lineprecision.txt
         python -m mypy --strict-equality extra/onnx_parser.py
+        python -m mypy --strict-equality extra/onnx.py
 
   unittest:
     name: Unit Tests
@@ -496,7 +497,7 @@ jobs:
         with:
           key: onnxoptc
           deps: testing
-          python-version: '3.10'  # keep one in 3.10
+          python-version: '3.11'
           llvm: 'true'
       - name: Test ONNX (CPU)
         run: CPU=1 python -m pytest -n=auto test/external/external_test_onnx_backend.py --durations=20

--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code="misc, list-item, assignment, attr-defined, operator, index, arg-type"
 from types import SimpleNamespace
 from typing import Any, Sequence, cast, Literal, Callable, get_args, NamedTuple
 import dataclasses, functools, io, math, types, warnings, pathlib, sys, enum


### PR DESCRIPTION
instead of running test with 3.10, add onnx to mypy which would have caught StrEnum regression. Several type annotation failed mypy now that does not affect running the code and were skipped for now